### PR TITLE
Add optional dependency to devour and prevent termv execution from changing PWD

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ the list of channels is obtained from [https://github.com/iptv-org/iptv](https:/
 - `mpv`
 - [`jq`](https://github.com/stedolan/jq)
 - [`fzf`](https://github.com/junegunn/fzf)
+- [`devour`](https://github.com/salman-abedin/devour) (optional)
 
 ## Usage
 

--- a/termv
+++ b/termv
@@ -12,17 +12,21 @@ play(){
     if [[ -n "$1" ]]; then
         echo "please wait"
         [ "$FULL_SCREEN" = true ] && MPV_FLAGS="$MPV_FLAGS --fs"
-        mpv "$1" $MPV_FLAGS
+        if type devour >/dev/null; then
+            devour mpv "$1" $MPV_FLAGS
+        else
+            mpv "$1" $MPV_FLAGS
+        fi
     fi
 }
 
 select_channel(){
     local fzf_opts=(--cycle --header="Select channel (Press Escape to exit)")
     local name var
-    while name=$(cat channels.json | jq ".[].name" | tr -d '"' |\
+    while name=$(cat "$CHANNEL_DIR"/channels.json | jq ".[].name" | tr -d '"' |\
                  sort | fzf "${fzf_opts[@]}"); do
         var=".[] | select(.name==\"$name\") | .url"
-        play "$(cat channels.json | jq "$var" | tr -d '"')"
+        play "$(cat $CHANNEL_DIR/channels.json | jq "$var" | tr -d '"')"
     done
 }
 
@@ -38,11 +42,10 @@ dep_check(){
     fi
 
     mkdir -p "$CHANNEL_DIR"
-    cd "$CHANNEL_DIR"
 
-    if [[ ! -f channels.json ]];then 
+    if [[ ! -f "$CHANNEL_DIR"/channels.json ]];then 
         echo "Downloading channel list "; 
-        wget -q --show-progress https://iptv-org.github.io/iptv/channels.json ||\
+        wget -q --show-progress https://iptv-org.github.io/iptv/channels.json -o "$CHANNEL_DIR"/channels.json ||\
             print_error "Cannot download channel list" 
     fi
 

--- a/termv
+++ b/termv
@@ -45,7 +45,7 @@ dep_check(){
 
     if [[ ! -f "$CHANNEL_DIR"/channels.json ]];then 
         echo "Downloading channel list "; 
-        wget -q --show-progress https://iptv-org.github.io/iptv/channels.json -o "$CHANNEL_DIR"/channels.json ||\
+        wget -q --show-progress https://iptv-org.github.io/iptv/channels.json -O "$CHANNEL_DIR"/channels.json ||\
             print_error "Cannot download channel list" 
     fi
 


### PR DESCRIPTION
Submitting just in case because I have it ready anyway, but no worries if you think this is out of scope for `termv`. I think keeping `termv` execution from changing directory would be welcome though. I didn't test in many situations, but it seemed to work fine and adequately detect if `devour` is in `$PATH`.

I couldn't make `devour` to work when using Fish shell though, but I'm new to Fish and maybe `devour` is simply not compatible.