### PR TITLE
Add Nix Flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,40 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1629481132,
+        "narHash": "sha256-JHgasjPR0/J1J3DRm4KxM4zTyAj4IOJY8vIl75v/kPI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "997f7efcb746a9c140ce1f13c72263189225f482",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1630845541,
+        "narHash": "sha256-DKj/0V+NNJe3sgRAZFb4yYFZFH0gXD1qNU8xiI87+GA=",
+        "path": "/nix/store/qlw72jb119llpwpz8cp8afhwvi82k97m-source",
+        "rev": "1e5c35dfbc8e0ad8c35aa1a6446f442ca1ec5234",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,36 @@
+{
+
+  description = "A terminal iptv player written in bash";
+  
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem
+      (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          packages.termv =
+            pkgs.stdenv.mkDerivation {
+              name = "termv";
+              src = self;
+              phases = [ "unpackPhase" "patchPhase" "installPhase" ];
+              patchPhase = with pkgs; ''
+                substituteInPlace termv \
+                  --replace curl ${curl}/bin/curl \
+                  --replace fzf ${fzf}/bin/fzf \
+                  --replace gawk ${gawk}/bin/gawk \
+                  --replace jq ${jq}/bin/jq \
+                  --replace mpv ${mpv}/bin/mpv \
+                  --replace xdo ${xdo}/bin/xdo
+              '';
+              installPhase = ''
+                install -m 755 -D termv $out/bin/termv
+              '';
+            };
+          defaultPackage = self.packages.${system}.termv;
+        }
+      );
+
+}


### PR DESCRIPTION
This PR makes this project a [Nix Flake](https://nixos.wiki/wiki/Flakes).
Users with a recent version of the [Nix](https://nixos.org/) package manager can then execute _termv_ with the following command:

```
nix run github:Roshan-R/termv
```

Nix is available for all Linux distributions, MacOS and Windows (via WSL) and provides reproducible builds.

If this is a Flake, it is also possible to install _termv_ as a system package on Flake-injected NixOS installations even though it's not available in the nixpkgs package repo.

Feel free to reject this PR if you want to keep the repo clean and don't see any use in this..
I just added it because I want to use it myself and thought some other people may enjoy this too.
Thank you for this nice script :)