### PR TITLE
Add category filter

### DIFF
--- a/termv
+++ b/termv
@@ -117,9 +117,11 @@ done
 
 [ "${TERMV_FULL_SCREEN}" = true ] && TERMV_MPV_FLAGS="${TERMV_MPV_FLAGS} --fs"
 
+[[ -n "${TERMV_CATEGORY}" ]] && echo "Chosen category: $TERMV_CATEGORY" && TERMV_FILTER="| select(.categories[0].name == \"$TERMV_CATEGORY\")"
+
 [ "${TERMV_AUTO_UPDATE}" = true ] && { [ ! "$(stat -c %y "${TERMV_CACHE_DIR:?}/data.json" 2>/dev/null | cut -d' ' -f1)" = "$(date '+%Y-%m-%d')" ] && update_channelsfile ; }
 
-CHANNELS_LIST=$(jq -r '.[] | "\(.name) \t \(.categories[].name // "N/A") \t \(.languages|.[0].name // "N/A") \t \(.countries|.[0].name // "N/A") \t \(.url)"' "${TERMV_CACHE_DIR:?}/data.json" |\
+CHANNELS_LIST=$(jq -r ".[] $TERMV_FILTER | \"\(.name) \t \(.categories[].name // \"N/A\") \t \(.languages|.[0].name // \"N/A\") \t \(.countries|.[0].name // \"N/A\") \t \(.url)\"" "${TERMV_CACHE_DIR:?}/data.json" |\
                 gawk -v max="${COLUMNS:-80}" 'BEGIN { RS="\n"; FS=" \t " }
                     {
                       name = substr(gensub(/[0-9]+\.\s*(.*)/, "\\1", "g", $1),0,max/4)


### PR DESCRIPTION
Allow the option of filtering by category before feeding the data into fzf. Related to #4  
Could also be used for language and NSFW(#19 ) filters by extending TERMV_FILTER