### PR TITLE
feat: enable to use TERMV_API_URL as env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
 
 `termv` is a small bash script that allows you to select an iptv stream using `fzf` and play it using `mpv`.
 
-the list of channels is obtained from [https://github.com/iptv-org/iptv](https://github.com/iptv-org/iptv)
+The list of channels is obtained from [https://github.com/iptv-org/iptv](https://github.com/iptv-org/iptv)
+For an example for a custom channels list and how to make one yourself, visit [this gist](https://gist.github.com/Roshan-R/7eddda0789297d86219fda21876b2632) 
 
 
 ## Dependencies

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Options:
     TERMV_SWALLOW             Always swallow terminal during playback. (default: false)
     TERMV_FULL_SCREEN         Always open mpv in fullscreen. (default: false)
     TERMV_DEFAULT_MPV_FLAGS   Default arguments which are passed to mpv. (default: --no-resume-playback)
+    TERMV_API_URL             URL to the channel list. (default: https://iptv-org.github.io/iptv/channels.json)
+                              Any other URL must be in the same format as the default one.
 
   Improve me on GitHub:
     https://github.com/Roshan-R/termv

--- a/termv
+++ b/termv
@@ -5,8 +5,10 @@ BASH_BINARY="$(which bash)"
 TERMV_CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/termv"
 TERMV_AUTO_UPDATE=${TERMV_AUTO_UPDATE:-true}
 TERMV_FULL_SCREEN=${TERMV_FULL_SCREEN:-false}
-TERMV_API_URL="https://iptv-org.github.io/iptv/channels.json"
+TERMV_API_URL=${TERMV_API_URL:-"https://iptv-org.github.io/iptv/channels.json"}
+
 FZF_VERSION=$(fzf --version | cut -d '.' -f 2- | cut -d ' ' -f 1 )
+
 declare -x TERMV_SWALLOW=${TERMV_SWALLOW:-false}
 declare -x TERMV_MPV_FLAGS="${TERMV_DEFAULT_MPV_FLAGS:---no-resume-playback}"
 
@@ -54,7 +56,8 @@ usage() {
     _phi "TERMV_SWALLOW             Always swallow terminal during playback. (default: false)"
     _phi "TERMV_FULL_SCREEN         Always open mpv in fullscreen. (default: false)"
     _phi "TERMV_DEFAULT_MPV_FLAGS   Default arguments which are passed to mpv. (default: --no-resume-playback)"
-    _pht
+    _phi "TERMV_API_URL             URL to the channel list. (default: https://iptv-org.github.io/iptv/channels.json)"
+    _phi "                          Any other URL must be in the same format as the default one."
     _pht "  Improve me on GitHub:"
     _phi "https://github.com/Roshan-R/termv"
 }


### PR DESCRIPTION
Is the user responsability to provide an URL that exposes a JSON with the same format as `http://iptv-org.github.io/iptv/channels.json`

For instance, I create a js script to parse my personal M3U into a compatible JSON and stored that json as a private GIST.